### PR TITLE
openAI 호출 및 응답 코드 작성 및 퀴즈 생성/제공 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,14 +19,14 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+	// implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+	// testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/org/zerock/finedu/finedubackend/config/OpenAIConfig.java
+++ b/src/main/java/org/zerock/finedu/finedubackend/config/OpenAIConfig.java
@@ -1,0 +1,26 @@
+package org.zerock.finedu.finedubackend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class OpenAIConfig {
+    @Value("${openai.api-key}")
+    private String openApiKey;
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+
+    public HttpHeaders createHttpHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + openApiKey);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return headers;
+    }
+}

--- a/src/main/java/org/zerock/finedu/finedubackend/controller/QuizController.java
+++ b/src/main/java/org/zerock/finedu/finedubackend/controller/QuizController.java
@@ -1,0 +1,26 @@
+package org.zerock.finedu.finedubackend.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.zerock.finedu.finedubackend.dto.response.QuizResponse;
+import org.zerock.finedu.finedubackend.service.QuizService;
+
+@RestController
+@RequestMapping("/quiz")
+@RequiredArgsConstructor
+public class QuizController {
+
+    private final QuizService quizService;
+
+    @PostMapping("/generate")
+    public ResponseEntity<QuizResponse> generateQuiz(@RequestParam Long summaryId) {
+        QuizResponse quiz = quizService.generateQuiz(summaryId);
+        return ResponseEntity.ok(quiz);
+    }
+
+
+}

--- a/src/main/java/org/zerock/finedu/finedubackend/dto/request/OpenAIRequest.java
+++ b/src/main/java/org/zerock/finedu/finedubackend/dto/request/OpenAIRequest.java
@@ -1,0 +1,13 @@
+package org.zerock.finedu.finedubackend.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class OpenAIRequest {
+    private String prompt;
+    @Builder
+    OpenAIRequest(String prompt) {
+        this.prompt = prompt;
+    }
+}

--- a/src/main/java/org/zerock/finedu/finedubackend/dto/response/QuizResponse.java
+++ b/src/main/java/org/zerock/finedu/finedubackend/dto/response/QuizResponse.java
@@ -1,0 +1,19 @@
+package org.zerock.finedu.finedubackend.dto.response;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class QuizResponse {
+    private Long quiz_id;        // 퀴즈 ID
+    private Long news_id;        // 뉴스 ID
+//    private Long summary_id;     // 요약 ID
+    private String quiz_title;   // 퀴즈 제목
+    private String question;     // 퀴즈 질문
+    private List<String> options; // 선택지
+    private String explanation;
+}

--- a/src/main/java/org/zerock/finedu/finedubackend/repository/NewsRepository.java
+++ b/src/main/java/org/zerock/finedu/finedubackend/repository/NewsRepository.java
@@ -1,0 +1,7 @@
+package org.zerock.finedu.finedubackend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.zerock.finedu.finedubackend.entity.NewsEntity;
+
+public interface NewsRepository extends JpaRepository<NewsEntity, Long> {
+}

--- a/src/main/java/org/zerock/finedu/finedubackend/repository/NewsSummaryRepository.java
+++ b/src/main/java/org/zerock/finedu/finedubackend/repository/NewsSummaryRepository.java
@@ -1,0 +1,7 @@
+package org.zerock.finedu.finedubackend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.zerock.finedu.finedubackend.entity.NewsSummaryEntity;
+
+public interface NewsSummaryRepository extends JpaRepository<NewsSummaryEntity, Long> {
+}

--- a/src/main/java/org/zerock/finedu/finedubackend/repository/QuizRepository.java
+++ b/src/main/java/org/zerock/finedu/finedubackend/repository/QuizRepository.java
@@ -1,0 +1,7 @@
+package org.zerock.finedu.finedubackend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.zerock.finedu.finedubackend.entity.QuizEntity;
+
+public interface QuizRepository extends JpaRepository<QuizEntity, Long> {
+}

--- a/src/main/java/org/zerock/finedu/finedubackend/service/OpenAIService.java
+++ b/src/main/java/org/zerock/finedu/finedubackend/service/OpenAIService.java
@@ -1,0 +1,60 @@
+package org.zerock.finedu.finedubackend.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.zerock.finedu.finedubackend.config.OpenAIConfig;
+import org.zerock.finedu.finedubackend.dto.request.OpenAIRequest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class OpenAIService {
+    private final OpenAIConfig openAIConfig;
+    private static final String OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${openai.model}")
+    private String model;
+
+    public OpenAIService(OpenAIConfig openAIConfig) {
+        this.openAIConfig = openAIConfig;
+    }
+
+    private HttpHeaders createHeaders() {
+        return openAIConfig.createHttpHeaders();
+    }
+
+    public String getResponseFromOpenAI(OpenAIRequest openAIRequest) {
+        HttpHeaders headers = createHeaders();
+
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("model", model);
+
+        Map<String, String> userMessage = new HashMap<>();
+        userMessage.put("role", "user");
+        userMessage.put("content", openAIRequest.getPrompt());
+        requestBody.put("messages", new Object[] { userMessage });
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+
+        ResponseEntity<String> response = openAIConfig.restTemplate()
+                .exchange(OPENAI_API_URL, HttpMethod.POST, entity, String.class);
+
+        if (response.getStatusCode() == HttpStatus.OK) {
+            try {
+                JsonNode root = objectMapper.readTree(response.getBody());
+                JsonNode choices = root.path("choices").get(0);
+                JsonNode message = choices.path("message");
+                return message.path("content").asText();
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to parse response from OpenAI", e);
+            }
+        } else {
+            throw new RuntimeException("Failed to fetch response from OpenAI: " + response.getStatusCode());
+        }
+    }
+}

--- a/src/main/java/org/zerock/finedu/finedubackend/service/QuizService.java
+++ b/src/main/java/org/zerock/finedu/finedubackend/service/QuizService.java
@@ -1,0 +1,119 @@
+package org.zerock.finedu.finedubackend.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.zerock.finedu.finedubackend.dto.request.OpenAIRequest;
+import org.zerock.finedu.finedubackend.dto.response.QuizResponse;
+import org.zerock.finedu.finedubackend.entity.NewsEntity;
+import org.zerock.finedu.finedubackend.entity.NewsSummaryEntity;
+import org.zerock.finedu.finedubackend.entity.QuizEntity;
+import org.zerock.finedu.finedubackend.repository.NewsRepository;
+import org.zerock.finedu.finedubackend.repository.NewsSummaryRepository;
+import org.zerock.finedu.finedubackend.repository.QuizRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class QuizService {
+
+    private final OpenAIService openAIService;
+    private final NewsSummaryRepository newsSummaryRepository;
+    private final NewsRepository newsRepository;
+    private final QuizRepository quizRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public QuizResponse generateQuiz(Long summaryId) {
+        // 1. 뉴스 요약 데이터 조회
+        // Optional<NewsSummaryEntity> optionalSummary = newsSummaryRepository.findById(summaryId);
+        Optional<NewsEntity> optionalSummary = newsRepository.findById(summaryId);
+        if (optionalSummary.isEmpty()) {
+            throw new IllegalArgumentException("News Summary not found with ID: " + summaryId);
+        }
+
+        //NewsSummaryEntity newsSummary = optionalSummary.get();
+        NewsEntity news = optionalSummary.get();
+
+        // 2. OpenAI에 요청할 프롬프트 생성
+        String prompt = String.format(
+                "다음 요약 내용을 기반으로 반드시 객관식 퀴즈를 생성해줘:\n" +
+                        "'%s'.\n\n퀴즈는 다음과 같은 형식으로 작성해줘:\n" +
+                        "{\n" +
+                        "  \"question\": \"자연스럽고 명확한 문장형 질문 (완전한 문장이어야 하며, 질문에서 물어보는 대상이 명확해야 함)\",\n" +
+                        "  \"options\": [\n" +
+                        "    \"질문에서 물어보는 대상의 품사와 일치하며 서로 다른 의미를 가진 선택지 1\",\n" +
+                        "    \"질문에서 물어보는 대상의 품사와 일치하며 서로 다른 의미를 가진 선택지 2\",\n" +
+                        "    \"질문에서 물어보는 대상의 품사와 일치하며 서로 다른 의미를 가진 선택지 3\",\n" +
+                        "    \"질문에서 물어보는 대상의 품사와 일치하며 서로 다른 의미를 가진 선택지 4\"\n" +
+                        "  ],\n" +
+                        "  \"answer\": 1에서 4 사이의 숫자 중 랜덤하게 선택된 정답 번호,\n" +
+                        "  \"explanation\": \"정답은 ~번입니다. 이유: 해당 선택지가 정답인 이유를 명확하고 자연스럽게 설명. 문장은 항상 '입니다'로 끝내세요.\"\n" +
+                        "}\n\n" +
+                        "반드시 지켜야 할 사항:\n" +
+                        "1. 질문(question)은 완전한 문장형이어야 하며, 모호하지 않고 명확하게 작성해야 하고 요약 내용과 직접적으로 관련된 질문을 만들어야 합니다. 문법적으로 올바르고 자연스럽게 작성해야 합니다.\n" +
+                        "2. 선택지는 질문에서 물어보는 대상의 품사와 일치해야 하며, 서로 다른 의미를 가지도록 작성해야 합니다. 그리고 자연스럽고 문법적으로 올바르게 작성되어야 합니다.\n" +
+                        "3. 정답(answer)은 1부터 4 사이의 랜덤한 숫자여야 합니다.\n" +
+                        "4. 해설(explanation)은 반드시 '정답은 ~번입니다.'로 시작한 후, 그 이유를 명확하고 구체적으로 설명해야 합니다. 문장은 항상 '입니다'로 끝나야 합니다.\n" +
+                        "5. 결과는 JSON 형식 그대로 반환해야 합니다.",
+                news.getNewsContent()
+        );
+
+        // 3. OpenAI API 호출
+        OpenAIRequest openAIRequest = OpenAIRequest.builder()
+                .prompt(prompt)
+                .build();
+
+        String openAIResponse = openAIService.getResponseFromOpenAI(openAIRequest);
+
+        try {
+            // 4. 응답 파싱
+            JsonNode responseJson = objectMapper.readTree(openAIResponse);
+
+            // 필드 추출
+            String question = responseJson.path("question").asText();
+            JsonNode optionsNode = responseJson.path("options"); // 선택지
+            int answer = responseJson.path("answer").asInt(); // 정답 인덱스
+            String explanation = responseJson.path("explanation").asText(); // 해설
+
+            // optionsNode를 List<String>으로 변환
+            List<String> options = new ArrayList<>();
+            if (optionsNode.isArray()) {
+                for (JsonNode option : optionsNode) {
+                    options.add(option.asText());
+                }
+            }
+
+            // options를 JSON String으로 변환하여 QuizEntity에 저장
+            String optionsJson = objectMapper.writeValueAsString(options);
+
+            // 5. QuizEntity 저장
+            QuizEntity quiz = new QuizEntity();
+//            quiz.setNewsSummary(newsSummary);
+            quiz.setQuizTitle(news.getNewsTitle());
+            quiz.setQuestion(question);
+            quiz.setOptions(optionsJson);
+            quiz.setAnswer(answer);
+            QuizEntity savedQuiz = quizRepository.save(quiz);
+
+            // 6. QuizResponse DTO로 변환
+            QuizResponse quizResponse = QuizResponse.builder()
+                    .quiz_id(savedQuiz.getQuiz_id())
+                    .news_id(news.getNews_id()) // 뉴스 ID
+//                    .summary_id(newsSummary.getSummary_id())    // 요약 ID
+                    .quiz_title(savedQuiz.getQuizTitle())
+                    .question(savedQuiz.getQuestion())
+                    .options(options) // List<String>으로 반환
+                    .explanation(explanation)
+                    .build();
+
+            return quizResponse;
+
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse OpenAI response", e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,8 +11,14 @@ spring:
     database-platform: org.hibernate.dialect.MySQLDialect
     show-sql: true
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
+
+openai:
+#  api-key:
+  model: gpt-3.5-turbo-0125
+
+


### PR DESCRIPTION
- DDL option: validate -> update
- postman 테스트를 위해 spring-web-security 주석처리
- 뉴스 요약 내용이 없어서 테스트를 위해 뉴스 content로 퀴즈 요약 생성 테스트,
- application.yml에 model, api-key 부분 작성

- openAI 호출 시에는 openAIService의 getResponseFromOpenAI(openAIRequest)만 호출하면 됨
- openAIRequest에 prompt를 담아 넘겨주도록 작성하였음