### PR TITLE
Feat : news summarize API, news summary API

### DIFF
--- a/src/main/java/org/zerock/finedu/finedubackend/controller/NewsController.java
+++ b/src/main/java/org/zerock/finedu/finedubackend/controller/NewsController.java
@@ -1,0 +1,78 @@
+package org.zerock.finedu.finedubackend.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.zerock.finedu.finedubackend.dto.response.NewsSummaryResponse;
+import org.zerock.finedu.finedubackend.service.NewsSummaryService;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/news")
+@RequiredArgsConstructor
+public class NewsController {
+
+    private final NewsSummaryService summaryService;
+
+    @GetMapping("/summary")
+    public ResponseEntity<?> getNewsSummary(
+            @RequestParam(required = false) String keyword,
+            @PageableDefault(size = 1) Pageable pageable) {
+
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return ResponseEntity.badRequest()
+                    .body(Map.of(
+                            "status", 400,
+                            "message", "키워드가 입력되지 않았습니다."
+                    ));
+        }
+
+        try {
+            // 단일 뉴스 요약 반환
+            NewsSummaryResponse summary = summaryService.getRandomSummaryByKeyword(keyword);
+
+            if (summary == null) {
+                return ResponseEntity.status(404)
+                        .body(Map.of(
+                                "status", 404,
+                                "message", "해당 키워드의 뉴스를 찾을 수 없습니다."
+                        ));
+            }
+
+            return ResponseEntity.ok(summary);
+
+        } catch (Exception e) {
+            return ResponseEntity.status(500)
+                    .body(Map.of(
+                            "status", 500,
+                            "message", "서버 처리 중 오류가 발생했습니다."
+                    ));
+        }
+    }
+
+    @GetMapping("/summary/{summaryId}")
+    public ResponseEntity<?> getNewsSummary(@PathVariable Long summaryId) {
+        try {
+            NewsSummaryResponse summary = summaryService.getSummaryById(summaryId);
+            return ResponseEntity.ok(summary);
+
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(404)
+                    .body(Map.of(
+                            "status", 404,
+                            "message", "해당 ID의 뉴스를 찾을 수 없습니다."
+                    ));
+
+        } catch (Exception e) {
+            return ResponseEntity.status(500)
+                    .body(Map.of(
+                            "status", 500,
+                            "message", "서버 처리 중 오류가 발생했습니다."
+                    ));
+        }
+    }
+}

--- a/src/main/java/org/zerock/finedu/finedubackend/dto/response/NewsSummaryResponse.java
+++ b/src/main/java/org/zerock/finedu/finedubackend/dto/response/NewsSummaryResponse.java
@@ -1,0 +1,22 @@
+package org.zerock.finedu.finedubackend.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NewsSummaryResponse {
+    private Long summaryId;
+    private Long newsId;
+    private String summaryTitle;
+    private String summaryContent;
+    private String keywords;
+    private String originalUrl;
+    private LocalDateTime publishTime;
+}

--- a/src/main/java/org/zerock/finedu/finedubackend/dto/response/QuizResponse.java
+++ b/src/main/java/org/zerock/finedu/finedubackend/dto/response/QuizResponse.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class QuizResponse {
     private Long quiz_id;        // 퀴즈 ID
     private Long news_id;        // 뉴스 ID
-//    private Long summary_id;     // 요약 ID
+    private Long summary_id;     // 요약 ID
     private String quiz_title;   // 퀴즈 제목
     private String question;     // 퀴즈 질문
     private List<String> options; // 선택지

--- a/src/main/java/org/zerock/finedu/finedubackend/entity/NewsEntity.java
+++ b/src/main/java/org/zerock/finedu/finedubackend/entity/NewsEntity.java
@@ -19,7 +19,7 @@ public class NewsEntity {
     @Column(name = "news_title")
     private String newsTitle;
 
-    @Column(name = "news_content")
+    @Column(name = "news_content", columnDefinition = "TEXT")
     private String newsContent;
 
     @Column(name= "original_url")

--- a/src/main/java/org/zerock/finedu/finedubackend/repository/NewsRepository.java
+++ b/src/main/java/org/zerock/finedu/finedubackend/repository/NewsRepository.java
@@ -1,7 +1,14 @@
 package org.zerock.finedu.finedubackend.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.zerock.finedu.finedubackend.entity.NewsEntity;
+import org.springframework.data.domain.Pageable;
+
+
+import java.util.List;
 
 public interface NewsRepository extends JpaRepository<NewsEntity, Long> {
+    @Query(value = "SELECT n FROM NewsEntity n WHERE n.newsSummary IS NULL ORDER BY n.crawlTime DESC")
+    List<NewsEntity> findByNewsSummaryIsNullOrderByCrawlTimeDesc(Pageable pageable);
 }

--- a/src/main/java/org/zerock/finedu/finedubackend/repository/NewsSummaryRepository.java
+++ b/src/main/java/org/zerock/finedu/finedubackend/repository/NewsSummaryRepository.java
@@ -1,7 +1,14 @@
 package org.zerock.finedu.finedubackend.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.zerock.finedu.finedubackend.entity.NewsSummaryEntity;
 
+import java.util.List;
+
 public interface NewsSummaryRepository extends JpaRepository<NewsSummaryEntity, Long> {
+    Page<NewsSummaryEntity> findByKeywordContainingOrderByNews_PublishTimeDesc(String keyword, Pageable pageable);
+    List<NewsSummaryEntity> findByKeywordContaining(String keyword);
+
 }

--- a/src/main/java/org/zerock/finedu/finedubackend/service/NewsSummarizeService.java
+++ b/src/main/java/org/zerock/finedu/finedubackend/service/NewsSummarizeService.java
@@ -1,0 +1,72 @@
+package org.zerock.finedu.finedubackend.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.zerock.finedu.finedubackend.dto.request.OpenAIRequest;
+import org.zerock.finedu.finedubackend.entity.NewsEntity;
+import org.zerock.finedu.finedubackend.entity.NewsSummaryEntity;
+import org.zerock.finedu.finedubackend.repository.NewsRepository;
+import org.zerock.finedu.finedubackend.repository.NewsSummaryRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NewsSummarizeService {
+
+    private final NewsRepository newsRepository;
+    private final NewsSummaryRepository summaryRepository;
+    private final OpenAIService openAIService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Transactional
+    public void summarizeUnprocessedNews(int batchSize) {
+        PageRequest pageRequest = PageRequest.of(0, batchSize);
+        List<NewsEntity> unprocessedNews = newsRepository.findByNewsSummaryIsNullOrderByCrawlTimeDesc(pageRequest);
+
+        for (NewsEntity news : unprocessedNews) {
+            try {
+                // OpenAI API 요청을 위한 프롬프트 생성
+                String prompt = String.format(
+                        "다음 금융 뉴스 내용을 200자 이내로 요약하고, 관련된 주요 금융 키워드를 3개 추출해주세요. 다음과 같은 JSON 형식으로 응답해주세요:\n" +
+                                "{\n" +
+                                "  \"summary\": \"요약된 내용 (금융 관련 중요 정보 위주로)\",\n" +
+                                "  \"keywords\": \"금융키워드1,금융키워드2,금융키워드3\"\n" +
+                                "}\n\n" +
+                                "뉴스 내용:\n%s",
+                        news.getNewsContent()
+                );
+
+                OpenAIRequest openAIRequest = OpenAIRequest.builder()
+                        .prompt(prompt)
+                        .build();
+
+                // OpenAI API 호출 및 응답 파싱
+                String response = openAIService.getResponseFromOpenAI(openAIRequest);
+                JsonNode responseJson = objectMapper.readTree(response);
+
+                // 요약 엔티티 생성 및 저장
+                NewsSummaryEntity summary = new NewsSummaryEntity();
+                summary.setNews(news);
+                summary.setSummaryTitle(generateSummaryTitle(news.getNewsTitle()));
+                summary.setSummaryContent(responseJson.get("summary").asText());
+                summary.setKeyword(responseJson.get("keywords").asText());
+
+                summaryRepository.save(summary);
+
+            } catch (Exception e) {
+                // 개별 뉴스 처리 실패 시 로그 기록 후 다음 뉴스 처리 진행
+                System.err.println("Failed to summarize news ID: " + news.getNews_id() + ". Error: " + e.getMessage());
+            }
+        }
+    }
+
+    private String generateSummaryTitle(String newsTitle) {
+        // 뉴스 제목에서 [] 등의 불필요한 태그 제거
+        return newsTitle.replaceAll("\\[.*?\\]", "").trim();
+    }
+}

--- a/src/main/java/org/zerock/finedu/finedubackend/service/NewsSummaryService.java
+++ b/src/main/java/org/zerock/finedu/finedubackend/service/NewsSummaryService.java
@@ -1,0 +1,66 @@
+package org.zerock.finedu.finedubackend.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.zerock.finedu.finedubackend.dto.response.NewsSummaryResponse;
+import org.zerock.finedu.finedubackend.entity.NewsSummaryEntity;
+import org.zerock.finedu.finedubackend.repository.NewsSummaryRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class NewsSummaryService {
+
+    private final NewsSummaryRepository summaryRepository;
+
+    @Transactional(readOnly = true)
+    public List<NewsSummaryResponse> getSummariesByKeyword(String keyword, Pageable pageable) {
+        Page<NewsSummaryEntity> summaries = summaryRepository.findByKeywordContainingOrderByNews_PublishTimeDesc(
+                keyword, pageable);
+
+        return summaries.stream()
+                .map(this::convertToResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public NewsSummaryResponse getSummaryById(Long summaryId) {
+        NewsSummaryEntity summary = summaryRepository.findById(summaryId)
+                .orElseThrow(() -> new IllegalArgumentException("Summary not found with id: " + summaryId));
+
+        return convertToResponse(summary);
+    }
+
+    private NewsSummaryResponse convertToResponse(NewsSummaryEntity entity) {
+        return NewsSummaryResponse.builder()
+                .summaryId(entity.getSummary_id())
+                .newsId(entity.getNews().getNews_id())
+                .summaryTitle(entity.getSummaryTitle())
+                .summaryContent(entity.getSummaryContent())
+                .keywords(entity.getKeyword())
+                .originalUrl(entity.getNews().getOriginalUrl())
+                .publishTime(entity.getNews().getPublishTime())
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public NewsSummaryResponse getRandomSummaryByKeyword(String keyword) {
+        List<NewsSummaryEntity> summaries = summaryRepository
+                .findByKeywordContaining(keyword);
+
+        if (summaries.isEmpty()) {
+            return null;
+        }
+
+        // 랜덤으로 1개 선택
+        int randomIndex = (int) (Math.random() * summaries.size());
+        NewsSummaryEntity randomSummary = summaries.get(randomIndex);
+
+        return convertToResponse(randomSummary);
+    }
+}


### PR DESCRIPTION
closed #4 

### what's new
NewsSummarize: 원본 -> 요약 변환 프로세스
- NewsSummarizeService
- NewsSummarizeController
- /news/summarize (POST) 엔드포인트
    - 뉴스DB에 있는 뉴스를 배치(기본값 10개)로 요약해서 요약본DB에 넣는다

NewsSummary: 요약본 조회 기능
- NewsSummaryService
- NewsSummaryController
- /news/summary (GET) 엔드포인트
    - 키워드 파라미터 값에 따라 요약된 뉴스 1개를 가져온다